### PR TITLE
update docstrings, fix bug in mean_photo_z_offset

### DIFF
--- a/dsigma/helpers.py
+++ b/dsigma/helpers.py
@@ -3,9 +3,9 @@
 import numpy as np
 from scipy.interpolate import make_interp_spline
 
-from astropy.units.quantity import Quantity
+from astropy import units as u
 
-__all__ = ['interpolate_over_redshift', 'spherical_to_cartesian']
+__all__ = ['interpolate_over_redshift', 'in_degrees', 'spherical_to_cartesian']
 
 
 def interpolate_over_redshift(f, z, *args, **kwargs):
@@ -33,11 +33,6 @@ def interpolate_over_redshift(f, z, *args, **kwargs):
     f_of_z : numpy.ndarray or astropy.units.quantity.Quantity
         Interpolated values.
 
-    Raises
-    ------
-    ValueError
-        If redshifts are negative.
-
     """
     z_min, z_max = np.amin(z), np.amax(z)
 
@@ -52,20 +47,39 @@ def interpolate_over_redshift(f, z, *args, **kwargs):
     y = make_interp_spline(a_support, y_support)(1.0 / (1 + z[idx]))
     y[idx] = y
 
-    if isinstance(y_support, Quantity):
+    if isinstance(y_support, u.Quantity):
         y = y * y_support.unit
 
     return y
 
 
-def spherical_to_cartesian(ra, dec):
-    """Convert spherical coordinates to cartesian coordinates on a unit sphere.
+def in_degrees(angle):
+    """Add a degree unit to an angle if it doesn't have a unit, yet.
 
     Parameters
     ----------
-    ra : float or numpy.ndarray
+    angle : astropy.units.quantity.Quantity
+        Angle with or without units.
+
+    Returns
+    -------
+    angle : astropy.units.quantity.Quantity
+        Angle with units.
+
+    """
+    if angle.unit == u.Unit(''):
+        data = u.Quantity(angle.value, u.deg, copy=False)
+    return data.to(u.deg)
+
+
+def spherical_to_cartesian(ra, dec):
+    """Convert spherical coordinates to Cartesian coordinates on a unit sphere.
+
+    Parameters
+    ----------
+    ra : astropy.units.quantity.Quantity
         Right ascension.
-    dec : float or numpy.ndarray
+    dec : astropy.units.quantity.Quantity
         Declination.
 
     Returns
@@ -74,7 +88,7 @@ def spherical_to_cartesian(ra, dec):
         Cartesian coordinates.
 
     """
-    x = np.cos(np.deg2rad(ra)) * np.cos(np.deg2rad(dec))
-    y = np.sin(np.deg2rad(ra)) * np.cos(np.deg2rad(dec))
-    z = np.sin(np.deg2rad(dec))
+    x = np.cos(ra) * np.cos(dec)
+    y = np.sin(ra) * np.cos(dec)
+    z = np.sin(dec)
     return x, y, z

--- a/dsigma/jackknife.py
+++ b/dsigma/jackknife.py
@@ -9,7 +9,7 @@ from scipy.ndimage import gaussian_filter
 from scipy.spatial import cKDTree
 from sklearn.cluster import DBSCAN, MiniBatchKMeans
 
-from .helpers import spherical_to_cartesian
+from .helpers import in_degrees, spherical_to_cartesian
 
 __all__ = ['compress_jackknife_fields', 'compute_jackknife_fields',
            'jackknife_resampling', 'smooth_correlation_matrix']
@@ -19,11 +19,11 @@ def compute_jackknife_fields(table, centers, distance_threshold=1,
                              weights=None, seed=None):
     """Compute the centers for jackknife regions using DBSCAN and KMeans.
 
-    The function first runs DBSCAN to identify continous fields of points.
+    The function first runs DBSCAN to identify continuous fields of points.
     Afterwards, KMeans clustering is run. The initial cluster centers are
-    random points from each continous field. The number of initial cluster
+    random points from each continuous field. The number of initial cluster
     centers per field is determined according to the total weight of each
-    continous field. The centers are defined in cartesian coordinates on a unit
+    continuous field. The centers are defined in cartesian coordinates on a unit
     sphere.
 
     Parameters
@@ -33,17 +33,18 @@ def compute_jackknife_fields(table, centers, distance_threshold=1,
         field IDs. The jackknife field for each galaxy will be added in the
         `field_jk` column.
     centers : int or numpy.ndarray
-        If int, total number of jackknife fields. Otherwise, the centers
+        If a number, total number of jackknife fields. Otherwise, the centers
         returned from a previous call to that function. This allows for
         different samples to have the same jackknife fields.
     distance_threshold : float, optional
         The angular separation in degrees used to link points and calculate
-        continous fields before running KMeans. Default is 1.
-    weights : None or numpy.ndarray, optional
-        Per-lens weights for clustering. If None, assume the same weight for
-        all points. Default is None.
+        continuous fields before running KMeans. Default is 1.
+    weights : numpy.ndarray or None, optional
+        Per-lens weights for clustering. If ``None``, assume the same weight
+        for all points. Default is ``None``.
     seed : int or None, optional
-        Random seed to iniatialize the random number generator.
+        Random seed to initialize the random number generator. Default is
+        ``None``.
 
     Returns
     -------
@@ -52,7 +53,7 @@ def compute_jackknife_fields(table, centers, distance_threshold=1,
 
     """
     xyz = np.column_stack(spherical_to_cartesian(
-        table['ra'].data, table['dec'].data))
+        in_degrees(table['ra'].quantity), in_degrees(table['dec'].quantity)))
 
     if isinstance(centers, np.ndarray):
         kdtree = cKDTree(centers)
@@ -74,7 +75,7 @@ def compute_jackknife_fields(table, centers, distance_threshold=1,
     w_c = np.bincount(c[c != -1], weights=weights[c != -1])
     if n_jk < len(w_c):
         msg = ("The number of jackknife regions cannot be smaller than the "
-               "number of continous fields. Try increasing "
+               "number of continuous fields. Try increasing "
                "`distance_threshold` or decreasing `centers`.")
         raise RuntimeError(msg)
 
@@ -149,9 +150,9 @@ def compress_jackknife_fields(table):
             k_min = 0 if i == 0 else np.cumsum(counts)[i - 1]
             k_max = np.cumsum(counts)[i]
             if key == 'w_sys':
-                table_jk[i][key] = np.sum(table[key][k_min:k_max])
+                table_jk[key][i] = np.sum(table[key][k_min:k_max])
             elif key == 'sum 1':
-                table_jk[i][key] = np.sum(table[key][k_min:k_max], axis=0)
+                table_jk[key][i] = np.sum(table[key][k_min:k_max], axis=0)
             elif np.sum(table['w_sys'][k_min:k_max]) > 0:
                 table_jk[key][i] = np.average(
                     table[key][k_min:k_max],
@@ -172,7 +173,7 @@ def smooth_correlation_matrix(cor, sigma, exclude_diagonal=True):
     exclude_diagonal : bool, optional
         Whether to exclude the diagonal from the smoothing. That is what should
         be done generally because the diagonal is 1 by definition. Default is
-        True.
+        ``True``.
 
     Returns
     -------
@@ -207,31 +208,31 @@ def jackknife_resampling(f, table_l, table_r=None, table_l_2=None,
 
     Parameters
     ----------
-    f : function
+    f : callable
         Function that returns a result for which we want to have uncertainties.
         The function must take exactly one positional argument, the lens table.
         Additionally, it can have several additional keyword arguments.
     table_l : astropy.table.Table
         Precompute results for the lenses. The catalog must have jackknife
         regions assigned to it.
-    table_r :astropy.table.Table, optional
+    table_r : astropy.table.Table or None, optional
         Precompute results for random lenses. The input function must accept
-        the random lens table via the `table_r` keyword argument. Default
-        is None.
-    table_l_2 : astropy.table.Table, optional
+        the random lens table via the ``table_r`` keyword argument. Default
+        is ``None``.
+    table_l_2 : astropy.table.Table or None, optional
         Precompute results for a second set of lenses.The input function must
-        accept the second lens table via the `table_l_2` keyword argument.
-        Default is None.
-    table_r_2 : astropy.table.Table, optional
+        accept the second lens table via the ``table_l_2`` keyword argument.
+        Default is ``None``.
+    table_r_2 : astropy.table.Table or None, optional
         Precompute results for a second set of random lenses. The input
-        function must accept the second random lens table via the `table_r_2`
-        keyword argument. Default is None.
-    compress : bool
+        function must accept the second random lens table via the ``table_r_2``
+        keyword argument. Default is ``None``.
+    compress : bool, optional
         If ``True``, compress jackknife fields via
         ``dsigma.jackknife.compress_jackknife_fields`` before performing the
         jackknife calculation. This can substantially improve performance.
         Default is ``True``.
-    kwargs : dict, optional
+    **kwargs
         Additional keyword arguments to be passed to the function.
 
     Returns

--- a/dsigma/physics.py
+++ b/dsigma/physics.py
@@ -26,7 +26,7 @@ def mpc_per_degree(z, cosmology=None, comoving=False):
         Cosmology to use for calculation. If ``None``, use
         ``dsigma.default_cosmology``. Default is ``None``.
     comoving : bool, optional
-        Use comoving distance instead of physical distance when True.
+        Use comoving distance instead of physical distance when ``True``.
         Default is ``False``.
 
     Returns
@@ -62,13 +62,13 @@ def critical_surface_density(
         are not passed. If ``None``, use ``dsigma.default_cosmology``. Default
         is ``None``.
     comoving : bool, optional
-        Flag for using comoving instead of physical units.
-    d_l : astropy.units.quantity.Quantity
+        Flag for using comoving instead of physical units. Default is ``True``.
+    d_l : astropy.units.quantity.Quantity, optional
         Comoving transverse distance to the lens. If not given, it is
-        calculated from the redshift provided.
-    d_s : astropy.units.quantity.Quantity
+        calculated from the redshift provided. Default is ``None``.
+    d_s : astropy.units.quantity.Quantity, optional
         Comoving transverse distance to the source. If not given, it is
-        calculated from the redshift provided.
+        calculated from the redshift provided. Default is ``None``.
 
     Returns
     -------
@@ -111,8 +111,8 @@ def effective_critical_surface_density(
     cosmology : astropy.cosmology or None, optional
         Cosmology to assume for calculations. If ``None``, use
         ``dsigma.default_cosmology``. Default is ``None``.
-    comoving : boolean, optional
-        Flag for using comoving instead of physical unit.
+    comoving : bool, optional
+        Flag for using comoving instead of physical units. Default is ``True``.
 
     Returns
     -------
@@ -148,11 +148,17 @@ def _to_camb(cosmology, sigma_8, n_s, z):
     cosmology : astropy.cosmology.FlatLambdaCDM
         Astropy cosmology.
     sigma_8 : float
-        Scale of fluctations at :math:`8 h^{-1} \, \mathrm{Mpc}`.
+        Scale of fluctuations at :math:`8 h^{-1} \, \mathrm{Mpc}`.
     n_s : float
         Primordial power spectrum index. Default is 0.96.
     z : numpy.ndarray
         Redshifts for which to compute the power spectrum.
+
+    Returns
+    -------
+    results : camb.results.CAMBdata
+        CAMB results object that contains information about the matter power
+        spectrum.
 
     Raises
     ------
@@ -160,12 +166,6 @@ def _to_camb(cosmology, sigma_8, n_s, z):
         If cosmology is not an instance of ``astropy.cosmology.FlatLambdaCDM``.
     ImportError
         If ``camb`` is not installed.
-
-    Returns
-    -------
-    results : camb.results.CAMBdata
-        CAMB results object that contains information about the matter power
-        spectrum.
 
     """
     if not isinstance(cosmology, FlatLambdaCDM):
@@ -271,7 +271,7 @@ def lens_magnification_shear_bias(
         Cosmology to assume for calculations. If ``None``, use
         ``dsigma.default_cosmology``. Default is ``None``.
     sigma_8 : float, optional
-        Scale of fluctations at :math:`8 h^{-1} \, \mathrm{Mpc}`. Default is
+        Scale of fluctuations at :math:`8 h^{-1} \, \mathrm{Mpc}`. Default is
         0.82.
     n_s : float, optional
         Primordial power spectrum index. Default is 0.96.
@@ -280,7 +280,7 @@ def lens_magnification_shear_bias(
         more accurate. Default is 10.
     n_ell : int, optional
         Number of :math:`\ell` bins used in the integral. Larger numbers will
-        be more accurate. Default is 200.
+        be more accurate. Default is 1000.
     bessel_function_zeros : int, optional
         The calculation involves an integral over the second order Bessel
         function :math:`J_2 (\ell \theta)` from :math:`\ell = 0` to
@@ -288,10 +288,10 @@ def lens_magnification_shear_bias(
         bound with the bessel_function_zeros-th zero point of the Bessel
         function. Larger number should lead to more accurate results. However,
         in practice, this also requires larger `n_ell`. Particularly, `n_ell`
-        should never fall below `bessel_function_zeros`.
+        should never fall below `bessel_function_zeros`. Default is 100.
     k_max : float, optional
-        The maximum wavenumber beyond which the power spectrum is assumed to be
-        0.
+        The maximum wavenumber (in :math:`\mathrm{Mpc}^{-1}`) beyond which the
+        power spectrum is assumed to be 0. Default is 100.
 
     Returns
     -------

--- a/dsigma/precompute.py
+++ b/dsigma/precompute.py
@@ -11,7 +11,7 @@ from astropy.units import UnitConversionError
 from astropy_healpix import HEALPix
 
 from . import default_cosmology
-from .helpers import interpolate_over_redshift
+from .helpers import interpolate_over_redshift, in_degrees
 from .physics import critical_surface_density
 from .physics import effective_critical_surface_density
 from .precompute_engine import precompute_engine
@@ -68,9 +68,9 @@ def photo_z_dilution_factor(z_l, table_c, cosmology=None, weighting=-2):
         z_l, z_s_true, d_l=d_l, d_s=d_s_true)
     w_ls = np.where(z_l < z_l_max, w_s * sigma_crit_phot**weighting, 0)
 
-    with np.errstate(divide='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         f_bias = (np.sum(w_ls, axis=-1) / np.sum(w_ls * np.where(
-            w_ls > 0, sigma_crit_phot / sigma_crit_true, 0), axis=-1)).value
+            w_ls > 0, sigma_crit_phot / sigma_crit_true, 1), axis=-1)).value
 
     # If no lens-source pair is found, default to 1.
     f_bias = np.where(np.sum(w_ls, axis=-1) == 0, 1, f_bias)
@@ -85,7 +85,7 @@ def mean_photo_z_offset(z_l, table_c, cosmology=None, weighting=-2):
     ----------
     z_l : float or numpy.ndarray
         Redshift(s) of the lens.
-    table_c : astropy.table.Table, optional
+    table_c : astropy.table.Table
         Photometric redshift calibration catalog.
     cosmology : astropy.cosmology or None, optional
         Cosmology to assume for calculations. If ``None``, use
@@ -120,11 +120,11 @@ def mean_photo_z_offset(z_l, table_c, cosmology=None, weighting=-2):
         w_s = np.tile(w_s, len(z_l)).reshape(z_l.shape)
 
     sigma_crit_phot = critical_surface_density(z_l, z_s, d_l=d_l, d_s=d_s)
-    w_ls = np.where(z_l > z_l_max, w_s * sigma_crit_phot**weighting, 0)
+    w_ls = np.where(z_l < z_l_max, w_s * sigma_crit_phot**weighting, 0)
 
     with np.errstate(divide='ignore'):
-        dz = (np.sum(w_ls, axis=-1) / np.sum(
-            w_ls * (z_s - z_s_true), axis=-1)).value
+        dz = (np.sum(w_ls * (z_s - z_s_true), axis=-1) / np.sum(
+            w_ls, axis=-1)).value
 
     # If no lens-source pair is found, default to 0.
     dz = np.where(np.sum(w_ls, axis=-1) == 0, 0, dz)
@@ -187,7 +187,7 @@ def precompute(
     comoving : bool, optional
         Whether to use comoving or physical quantities for radial bins (if
         given in physical units) and the excess surface density. Default is
-        True.
+        ``True``.
     weighting : float, optional
         The exponent of weighting of each lens-source pair by the critical
         surface density. A natural choice is -2 which minimizes shape noise.
@@ -198,9 +198,9 @@ def precompute(
         It has to be a power of 2. May impact performance. Default is 256.
     n_jobs : int, optional
         Number of jobs to run at the same time. Default is 1.
-    progress_bar : bool, option
+    progress_bar : bool, optional
         Whether to show a progress bar for the main loop over lens pixels.
-        Default is False.
+        Default is ``False``.
 
     Returns
     -------
@@ -250,7 +250,7 @@ def precompute(
                    "non-negative integers.")
             raise ValueError(msg)
         if np.amax(table_s['z_bin']) >= table_n['n'].data.shape[1]:
-            msg = ("The source table contains more redshift bins than where "
+            msg = ("The source table contains more redshift bins than were "
                    "passed via the `table_n` argument.")
             raise ValueError(msg)
     elif 'z_l_max' in table_s.colnames and np.any(
@@ -260,11 +260,6 @@ def precompute(
         raise ValueError(msg)
 
     hp = HEALPix(nside, order='ring')
-
-    def in_degrees(data):
-        if data.unit == u.Unit(''):
-            data = u.Quantity(data.value, u.deg, copy=False)
-        return data.to(u.deg)
 
     pix_l = hp.lonlat_to_healpix(in_degrees(table_l['ra'].quantity),
                                  in_degrees(table_l['dec'].quantity))

--- a/dsigma/stacking.py
+++ b/dsigma/stacking.py
@@ -100,7 +100,7 @@ def boost_factor(table_l, table_r):
     ----------
     table_l : astropy.table.Table
         Precompute results for the lenses.
-    table_r : astropy.table.Table, optional
+    table_r : astropy.table.Table
         Precompute results for random lenses.
 
     Returns
@@ -126,8 +126,8 @@ def scalar_shear_response_factor(table_l, selection_bias=False):
     table_l : astropy.table.Table
         Precompute results for the lenses.
     selection_bias : bool
-        If True, calculate the selection bias :math:`m_\mathrm{sel}`, instead.
-        Default is False.
+        If ``True``, calculate the selection bias :math:`m_\mathrm{sel}`,
+        instead. Default is ``False``.
 
     Returns
     -------
@@ -144,7 +144,7 @@ def scalar_shear_response_factor(table_l, selection_bias=False):
 def matrix_shear_response_factor(table_l):
     r"""Compute the mean tangential response.
 
-    The tangential shear response factor:math:`R_t` is defined such that
+    The tangential shear response factor :math:`R_t` is defined such that
     :math:`\gamma_{\mathrm obs} = R_t \gamma_{\mathrm intrinsic}`.
 
     Parameters
@@ -163,7 +163,7 @@ def matrix_shear_response_factor(table_l):
 
 
 def shear_responsivity_factor(table_l):
-    """Compute the shear responsitivity factor.
+    """Compute the shear responsivity factor.
 
     Parameters
     ----------
@@ -173,7 +173,7 @@ def shear_responsivity_factor(table_l):
     Returns
     -------
     r : numpy.ndarray
-        Shear responsitivity factor in each radial bin.
+        Shear responsivity factor in each radial bin.
 
     """
     return (
@@ -225,9 +225,9 @@ def mean_critical_surface_density(table_l, photo_z_dilution_correction=False):
     table_l : astropy.table.Table
         Precompute results for the lenses.
     photo_z_dilution_correction : bool, optional
-        If True, correct for photo-z biases. This can only be done if a
+        If ``True``, correct for photo-z biases. This can only be done if a
         calibration catalog has been provided in the precomputation phase.
-        Default is False.
+        Default is ``False``.
 
     Returns
     -------
@@ -258,19 +258,19 @@ def lens_magnification_bias(table_l, alpha_l, sigma_8=0.82, n_s=0.96,
     alpha_l : float
         The response of the lenses to magnification.
     sigma_8 : float, optional
-        Scale of fluctations at :math:`8 h^{-1} \, \mathrm{Mpc}`. Default is
+        Scale of fluctuations at :math:`8 h^{-1} \, \mathrm{Mpc}`. Default is
         0.82.
     n_s : float, optional
         Primordial power spectrum index. Default is 0.96.
     photo_z_dilution_correction : bool, optional
-        If True, correct the mean critical surface density for photo-z biases.
-        Not used if `shear` is True. This should be consistent with what is
-        used for calculating the total excess surface density. Default is
-        False.
+        If ``True``, correct the mean critical surface density for photo-z
+        biases. Not used if `shear` is ``True``. This should be consistent with
+        what is used for calculating the total excess surface density. Default
+        is ``False``.
     shear : bool, optional
-        If True, return bias of the mean tangential shear. Otherwise, return
-        an estimate for the bias of the excess surface density. Default is
-        False.
+        If ``True``, return bias of the mean tangential shear. Otherwise,
+        return an estimate for the bias of the excess surface density. Default
+        is ``False``.
 
     Returns
     -------
@@ -317,34 +317,34 @@ def tangential_shear(table_l, table_r=None, boost_correction=False,
     table_l : astropy.table.Table
         Precompute results for the lenses.
     table_r : astropy.table.Table, optional
-        Precompute results for random lenses. Default is None.
+        Precompute results for random lenses. Default is ``None``.
     boost_correction : bool, optional
-        If True, calculate and apply a boost factor correction. This can only
-        be done if a random catalog is provided. Default is False.
-    scalar_shear_response_correction : bool or string, optional
+        If ``True``, calculate and apply a boost factor correction. This can
+        only be done if a random catalog is provided. Default is ``False``.
+    scalar_shear_response_correction : bool, optional
         Whether to correct for the multiplicative shear bias (scalar form).
-        Default is False.
-    matrix_shear_response_correction : bool or string, optional
+        Default is ``False``.
+    matrix_shear_response_correction : bool, optional
         Whether to correct for the multiplicative shear bias (tensor form).
-        Default is False.
+        Default is ``False``.
     shear_responsivity_correction : bool, optional
-        If True, correct for the shear responsivity. Default is False.
+        If ``True``, correct for the shear responsivity. Default is ``False``.
     selection_bias_correction : bool, optional
-        If True, correct for the multiplicative selection bias in, e.g., HSC.
-        Default is False.
+        If ``True``, correct for the multiplicative selection bias in, e.g.,
+        HSC. Default is ``False``.
     random_subtraction : bool, optional
-        If True, subtract the signal around randoms. This can only be done if
-        a random catalog is provided. Default is False.
+        If ``True``, subtract the signal around randoms. This can only be done
+        if a random catalog is provided. Default is ``False``.
     return_table : bool, optional
-        If True, return a table with many intermediate steps of the
+        If ``True``, return a table with many intermediate steps of the
         computation. Otherwise, a simple array with just the final tangential
-        shearis returned. Default is False.
+        shear is returned. Default is ``False``.
 
     Returns
     -------
     gt : numpy.ndarray or astropy.table.Table
         The tangential shear in each radial bin specified in the precomputation
-        phase. If `return_table` is True, will return a table with detailed
+        phase. If `return_table` is ``True``, will return a table with detailed
         information for each radial bin. The final result is in the column
         `gt`.
 
@@ -426,40 +426,40 @@ def excess_surface_density(table_l, table_r=None,
     table_l : astropy.table.Table
         Precompute results for the lenses.
     table_r : astropy.table.Table, optional
-        Precompute results for random lenses. Default is None.
+        Precompute results for random lenses. Default is ``None``.
     photo_z_dilution_correction : bool, optional
-        If True, correct for photo-z biases. This can only be done if a
+        If ``True``, correct for photo-z biases. This can only be done if a
         calibration catalog has been provided in the precomputation phase.
-        Default is False.
+        Default is ``False``.
     boost_correction : bool, optional
-        If true, calculate and apply a boost factor correction. This can only
-        be done if a random catalog is provided. Default is False.
+        If ``True``, calculate and apply a boost factor correction. This can
+        only be done if a random catalog is provided. Default is ``False``.
     scalar_shear_response_correction : bool or string, optional
         Whether to correct for the multiplicative shear bias (scalar form).
-        Default is False.
+        Default is ``False``.
     matrix_shear_response_correction : bool or string, optional
         Whether to correct for the multiplicative shear bias (tensor form).
-        Default is False.
+        Default is ``False``.
     shear_responsivity_correction : bool, optional
-        If True, correct for the shear responsivity. Default is False.
+        If ``True``, correct for the shear responsivity. Default is ``False``.
     selection_bias_correction : bool, optional
-        If True, correct for the multiplicative selection bias in, e.g., HSC.
-        Default is False.
+        If ``True``, correct for the multiplicative selection bias in, e.g.,
+        HSC. Default is ``False``.
     random_subtraction : bool, optional
-        If True, subtract the signal around randoms. This can only be done if
-        a random catalog is provided. Default is False.
+        If ``True``, subtract the signal around randoms. This can only be done
+        if a random catalog is provided. Default is ``False``.
     return_table : bool, optional
-        If True, return a table with many intermediate steps of the
+        If ``True``, return a table with many intermediate steps of the
         computation. Otherwise, a simple array with just the final excess
-        surface density is returned. Default is False.
+        surface density is returned. Default is ``False``.
 
     Returns
     -------
     ds : numpy.ndarray or astropy.table.Table
         The excess surface density in each radial bin specified in the
-        precomputation phase. If `return_table` is True, will return a table
-        with detailed information for each radial bin. The final result is in
-        the column `ds`.
+        precomputation phase. If `return_table` is ``True``, will return a
+        table with detailed information for each radial bin. The final result
+        is in the column `ds`.
 
     Raises
     ------

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -40,10 +40,10 @@ def test_treecorr(test_catalogs, n_jobs):
 
     assert np.all(
         np.array(ng.npairs, dtype=int) == stacking.number_of_pairs(table_l))
-    assert np.all(np.isclose(ng.xi, stacking.raw_tangential_shear(
-        table_l), atol=1e-9, rtol=0))
-    assert np.all(np.isclose(nk.xi, stacking.scalar_shear_response_factor(
-        table_l), atol=1e-8, rtol=0))
+    assert np.allclose(ng.xi, stacking.raw_tangential_shear(
+        table_l), atol=1e-9, rtol=0)
+    assert np.allclose(nk.xi, stacking.scalar_shear_response_factor(
+        table_l), atol=1e-8, rtol=0)
 
 
 def test_brute_force(test_catalogs):
@@ -126,9 +126,9 @@ def test_comoving(test_catalogs):
 
     assert np.all(stacking.number_of_pairs(table_l_phy) ==
                   stacking.number_of_pairs(table_l_com))
-    assert np.all(np.isclose(
+    assert np.allclose(
         stacking.raw_excess_surface_density(table_l_phy) / (1 + z_l)**2,
-        stacking.raw_excess_surface_density(table_l_com), atol=1e-9, rtol=0))
+        stacking.raw_excess_surface_density(table_l_com), atol=1e-9, rtol=0)
 
 
 def test_little_h(test_catalogs):
@@ -166,18 +166,20 @@ def test_f_bias_1(test_catalogs):
     table_l = precompute.precompute(table_l, table_s, rp_bins, table_c=table_c)
     f_bias = stacking.photo_z_dilution_factor(table_l)
 
-    assert np.all(np.isclose(f_bias, 1.0, rtol=0, atol=1e-12))
+    assert np.allclose(f_bias, 1.0, rtol=0, atol=1e-12)
 
 
 def test_f_bias_2(test_catalogs):
     # Check that f_bias corrects redshift offsets.
+
+    z_true = 0.7
 
     table_l, table_s = test_catalogs
     table_s['z'] = 0.5
     table_l['z'] = 0.2
     table_c = Table()
     table_c['z'] = np.repeat(0.5, 1)
-    table_c['z_true'] = 0.7
+    table_c['z_true'] = z_true
     table_c['w'] = 1.0
     table_c['w_sys'] = 1.0
 
@@ -186,11 +188,13 @@ def test_f_bias_2(test_catalogs):
     ds_1 = stacking.excess_surface_density(
         table_l, photo_z_dilution_correction=True)
 
+    assert np.allclose(z_true, stacking.mean_source_redshift(table_l))
+
     table_s['z'] = 0.7
     table_l = precompute.precompute(table_l, table_s, rp_bins)
     ds_2 = stacking.excess_surface_density(table_l)
 
-    assert np.all(np.isclose(ds_1, ds_2, rtol=0, atol=1e-6))
+    assert np.allclose(ds_1, ds_2, rtol=0, atol=1e-6)
 
 
 def test_nz(test_catalogs):


### PR DESCRIPTION
This PR fixes some inconsistencies and minor errors in the docstrings. It also fixes a bug in ``dsigma.precompute.mean_photo_z_offset`` where I accidentally required ``z_l > z_l_max`` instead of ``z_l < z_l_max``. I added a test to check that function.

Disclaimer: Claude Sonnet 4.6 was used to check the docstrings for errors and the code for potential bugs. It found some but not all inconsistencies in the docstrings. It flagged several potential bugs in the code but only the one in ``dsigma.precompute.mean_photo_z_offset`` turned out to be genuine whereas many other suggestions were incorrect.