### PR TITLE
fix crash when angular coordinates have units

### DIFF
--- a/dsigma/helpers.py
+++ b/dsigma/helpers.py
@@ -68,8 +68,8 @@ def in_degrees(angle):
 
     """
     if angle.unit == u.Unit(''):
-        data = u.Quantity(angle.value, u.deg, copy=False)
-    return data.to(u.deg)
+        angle = u.Quantity(angle.value, u.deg, copy=False)
+    return angle.to(u.deg)
 
 
 def spherical_to_cartesian(ra, dec):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from astropy import units as u
 from astropy.table import Table
 
 
@@ -20,9 +21,9 @@ def test_catalogs():
     table_l['w_sys'] = np.random.uniform(low=0.8, high=1.2, size=n_l)
 
     table_s = Table()
-    table_s['ra'] = np.random.uniform(low=0, high=30, size=n_s)
+    table_s['ra'] = np.random.uniform(low=0, high=30, size=n_s) * u.deg
     table_s['dec'] = np.rad2deg(np.arcsin(np.random.uniform(
-        low=0, high=np.sin(np.deg2rad(30)), size=n_s)))
+        low=0, high=np.sin(np.deg2rad(30)), size=n_s))) * u.deg
     table_s['z'] = np.random.uniform(low=0.2, high=0.7, size=n_s)
     table_s['w'] = np.random.uniform(low=0.8, high=1.2, size=n_s)
     table_s['e_1'] = np.random.normal(loc=0, scale=0.2, size=n_s)

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -74,11 +74,11 @@ def test_brute_force(test_catalogs):
 
     for i in range(len(table_l)):
         theta = np.arccos(
-            np.sin(np.deg2rad(table_l['dec'][i].value)) *
+            np.sin(np.deg2rad(table_l['dec'].value[i])) *
             np.sin(np.deg2rad(table_s['dec'].value)) +
-            np.cos(np.deg2rad(table_l['dec'][i].value)) *
+            np.cos(np.deg2rad(table_l['dec'].value[i])) *
             np.cos(np.deg2rad(table_s['dec'].value)) *
-            np.cos(np.deg2rad(table_l['ra'][i].value - table_s['ra'].value)))
+            np.cos(np.deg2rad(table_l['ra'].value[i] - table_s['ra'].value)))
         rp = WMAP7.comoving_distance(table_l['z'][i]).to(
             u.Mpc / cu.littleh, cu.with_H0(cosmology.H0)) * theta
         use = (table_s['z'] > table_l['z'][i]) & (rp <= np.amax(rp_bins))
@@ -93,7 +93,7 @@ def test_brute_force(test_catalogs):
         sum_w_ls += table_l['w_sys'][i] * np.histogram(
             rp, bins=rp_bins, weights=w_ls)[0]
         cos_2phi, sin_2phi = projection_angle(
-            table_l['ra'][i].value, table_l['dec'][i].value,
+            table_l['ra'].value[i], table_l['dec'].value[i],
             table_s['ra'][use].value, table_s['dec'][use].value)
         e_t = - cos_2phi * table_s['e_1'][use] + sin_2phi * table_s['e_2'][use]
         sum_w_ls_e_t += table_l['w_sys'][i] * np.histogram(

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -74,11 +74,11 @@ def test_brute_force(test_catalogs):
 
     for i in range(len(table_l)):
         theta = np.arccos(
-            np.sin(np.deg2rad(table_l['dec'][i])) *
-            np.sin(np.deg2rad(table_s['dec'])) +
-            np.cos(np.deg2rad(table_l['dec'][i])) *
-            np.cos(np.deg2rad(table_s['dec'])) *
-            np.cos(np.deg2rad(table_l['ra'][i] - table_s['ra'])))
+            np.sin(np.deg2rad(table_l['dec'][i].value)) *
+            np.sin(np.deg2rad(table_s['dec'].value)) +
+            np.cos(np.deg2rad(table_l['dec'][i].value)) *
+            np.cos(np.deg2rad(table_s['dec'].value)) *
+            np.cos(np.deg2rad(table_l['ra'][i].value - table_s['ra'].value)))
         rp = WMAP7.comoving_distance(table_l['z'][i]).to(
             u.Mpc / cu.littleh, cu.with_H0(cosmology.H0)) * theta
         use = (table_s['z'] > table_l['z'][i]) & (rp <= np.amax(rp_bins))
@@ -93,8 +93,8 @@ def test_brute_force(test_catalogs):
         sum_w_ls += table_l['w_sys'][i] * np.histogram(
             rp, bins=rp_bins, weights=w_ls)[0]
         cos_2phi, sin_2phi = projection_angle(
-            table_l['ra'][i], table_l['dec'][i], table_s['ra'][use],
-            table_s['dec'][use])
+            table_l['ra'][i].value, table_l['dec'][i].value,
+            table_s['ra'][use].value, table_s['dec'][use].value)
         e_t = - cos_2phi * table_s['e_1'][use] + sin_2phi * table_s['e_2'][use]
         sum_w_ls_e_t += table_l['w_sys'][i] * np.histogram(
             rp, bins=rp_bins, weights=w_ls * e_t)[0]


### PR DESCRIPTION
This PR fixes a crash when angular coordinates in the tables have units.

**AI Disclaimer**: Claude Sonnet 4.6 pointed out the bug when discussing type hinting. All code changes are mine.