### PR TITLE
fix: Fix pair-finding when max separation is below HEALPix pixel size

### DIFF
--- a/dsigma/precompute_engine.pyx
+++ b/dsigma/precompute_engine.pyx
@@ -215,7 +215,7 @@ def precompute_engine(
             dy = y_pix_l[i_pix_l] - y_pix_s[i_pix_s]
             dz = z_pix_l[i_pix_l] - z_pix_s[i_pix_s]
             chord_sq_pix_min = dx * dx + dy * dy + dz * dz
-            chord_sq_pix_min = pow(sqrt(chord_sq_pix_min) - 2 * max_pixrad, 2)
+            chord_sq_pix_min = pow(fmax(sqrt(chord_sq_pix_min) - 2 * max_pixrad, 0.0), 2)
 
             # Loop over all lenses in the pixel.
             for i_l in range(i_l_min, i_l_max):

--- a/tests/test_precompute.py
+++ b/tests/test_precompute.py
@@ -1,10 +1,42 @@
 import numpy as np
 import pytest
-from astropy.cosmology import LambdaCDM
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.cosmology import LambdaCDM, FlatLambdaCDM
 from astropy.table import Table
-
 from dsigma.precompute import precompute
 from fixtures import test_catalogs
+
+
+def test_pairs_below_pixel_size():
+    # Each lens gets one source 30" away, far below the nside=256 pixel
+    # (~13.7'). The sub-pixel search radius must not cause the pixel
+    # pre-filter to drop same-pixel pairs, so #pairs == #lenses.
+    ra, dec = np.meshgrid(np.linspace(10.0, 18.0, 25),
+                          np.linspace(-8.0, 8.0, 20))
+    ra, dec = ra.ravel(), dec.ravel()
+    n = ra.size
+
+    table_l = Table()
+    table_l['ra'] = ra * u.deg
+    table_l['dec'] = dec * u.deg
+    table_l['z'] = np.full(n, 0.2)
+    table_l['w_sys'] = np.ones(n)
+
+    c_s = SkyCoord(table_l['ra'], table_l['dec']).directional_offset_by(
+        0 * u.deg, 30 * u.arcsec)
+    table_s = Table()
+    table_s['ra'] = c_s.ra
+    table_s['dec'] = c_s.dec
+    table_s['z'] = np.full(n, 0.8)
+    table_s['w'] = np.ones(n)
+    table_s['e_1'] = np.zeros(n)
+    table_s['e_2'] = np.zeros(n)
+
+    rp_bins = [15, 60] * u.arcsec
+    table_l = precompute(table_l, table_s, rp_bins,
+                         cosmology=FlatLambdaCDM(70, 0.2, 0.7))
+    assert table_l['sum 1'].sum() == n
 
 
 def test_warnings_errors(test_catalogs):


### PR DESCRIPTION
`precompute_engine.pyx` computes a per-pixel-pair lower bound on lens–source separation as `pow(sqrt(chord_sq_pix_min) - 2*max_pixrad, 2)`, at [this line](https://github.com/johannesulf/dsigma/blob/854847b2f7db5fbd9c12fe19861e0b36ea1fd930/dsigma/precompute_engine.pyx#L218). 

When pixel centers are closer than `2*max_pixrad` (co-located pixels), the inner term goes negative and squaring inflates the "minimum" up to `4*max_pixrad**2`. The skip check `chord_sq_bins[...n_bins] < chord_sq_pix_min` then drops the closest pairs when the outermost bin is smaller than ~`2*max_pixrad` (0.48° at the default `nside=256`).

I hit this doing small-scale GGL, where I do not care about `rp_max` being large, I set it to 5 / 60, which is sub-pixel at the default nside. This causes inner-bin pairs were silently dropped. Fix is a one-liner.

Either clamping to 0.0 or increasing `nside=2048`? I think clamping is the safest as it avoids bug altogether, even for smaller choices of maximum separation and doesn't increase compute time.

**AI Disclaimer**: AI identified and solved the bug.